### PR TITLE
Allow Symfony 4.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "ext-json": "*",
-        "symfony/property-access": "^2.7|^3.0"
+        "symfony/property-access": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpunit/phpunit": "^5.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0"
+        "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0"
     },
     "autoload": {
         "psr-4": { "Ivory\\JsonBuilder\\": "src/" }


### PR DESCRIPTION
This PR adds support for Symfony 4.0 that will be released on Nov 30 2017.

#SymfonyConHackday2017